### PR TITLE
fix: incomplete string escaping or encoding

### DIFF
--- a/packages/examples/@vue+cli@4-example/public/index.html
+++ b/packages/examples/@vue+cli@4-example/public/index.html
@@ -15,9 +15,6 @@
         continue.</strong
       >
     </noscript>
-    <script>
-      globalThis.import_meta_env = JSON.parse('"import_meta_env_placeholder"');
-    </script>
     <div id="app"></div>
     <!-- built files will be auto injected -->
   </body>

--- a/packages/examples/@vue+cli@4-example/src/import-meta-env.js
+++ b/packages/examples/@vue+cli@4-example/src/import-meta-env.js
@@ -1,0 +1,1 @@
+globalThis.import_meta_env = JSON.parse('"import_meta_env_placeholder"');

--- a/packages/examples/@vue+cli@4-example/src/main.js
+++ b/packages/examples/@vue+cli@4-example/src/main.js
@@ -1,3 +1,4 @@
+import "./import-meta-env";
 import Vue from "vue";
 import App from "./App.vue";
 

--- a/packages/examples/babel-starter-example/src/import-meta-env.js
+++ b/packages/examples/babel-starter-example/src/import-meta-env.js
@@ -1,0 +1,1 @@
+globalThis.import_meta_env = JSON.parse('"import_meta_env_placeholder"');

--- a/packages/examples/babel-starter-example/src/index.js
+++ b/packages/examples/babel-starter-example/src/index.js
@@ -1,2 +1,3 @@
+import "./import-meta-env";
 console.log(`Hello: ${import.meta.env.HELLO}`);
 console.log(`JSON: ${JSON.stringify(JSON.parse(import.meta.env.JSON))}`);

--- a/packages/examples/jest-example/src/hello.ts
+++ b/packages/examples/jest-example/src/hello.ts
@@ -1,1 +1,2 @@
+import "./import-meta-env";
 export const hello = import.meta.env.HELLO;

--- a/packages/examples/jest-example/src/import-meta-env.ts
+++ b/packages/examples/jest-example/src/import-meta-env.ts
@@ -1,0 +1,2 @@
+// @ts-ignore
+globalThis.import_meta_env = JSON.parse('"import_meta_env_placeholder"');

--- a/packages/examples/mocha-example/src/hello.js
+++ b/packages/examples/mocha-example/src/hello.js
@@ -1,1 +1,2 @@
+import "./import-meta-env";
 export const hello = import.meta.env.HELLO;

--- a/packages/examples/mocha-example/src/import-meta-env.js
+++ b/packages/examples/mocha-example/src/import-meta-env.js
@@ -1,0 +1,1 @@
+globalThis.import_meta_env = JSON.parse('"import_meta_env_placeholder"');

--- a/packages/examples/nx-react-example/apps/app/src/app/app.tsx
+++ b/packages/examples/nx-react-example/apps/app/src/app/app.tsx
@@ -1,3 +1,4 @@
+import './import-meta-env';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import styles from './app.module.css';
 

--- a/packages/examples/nx-react-example/apps/app/src/app/import-meta-env.ts
+++ b/packages/examples/nx-react-example/apps/app/src/app/import-meta-env.ts
@@ -1,0 +1,3 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+globalThis.import_meta_env = JSON.parse('"import_meta_env_placeholder"');

--- a/packages/examples/nx-react-example/apps/app/src/index.html
+++ b/packages/examples/nx-react-example/apps/app/src/index.html
@@ -10,6 +10,5 @@
   </head>
   <body>
     <div id="root"></div>
-    <script>globalThis.import_meta_env=JSON.parse('"import_meta_env_placeholder"')</script>
   </body>
 </html>


### PR DESCRIPTION
BREAKING CHANGE: As of this commit, the special expresssion (`globalThis.import_meta_env = JSON.parse('"import_meta_env_placeholder"');`) needs to be transformed via transfomers

index.html:

```diff
- <script>
-   globalThis.import_meta_env = JSON.parse('"import_meta_env_placeholder"');
- </script>
<script type="module" src="./main.js"></script>
```

main.js

```diff
+ globalThis.import_meta_env = JSON.parse('"import_meta_env_placeholder"');
console.log(import.meta.env.HELLO)
```

fix: CWE-20